### PR TITLE
Linkify url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
 
-gem 'autolink'
+gem 'rails_autolink'
 
 # Use Unicorn as the app server
 gem 'unicorn'

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
 
+gem 'autolink'
+
 # Use Unicorn as the app server
 gem 'unicorn'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ GEM
     arbre (1.0.3)
       activesupport (>= 3.0.0)
     arel (6.0.3)
+    autolink (3.0.0)
     bcrypt (3.1.10)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -268,6 +269,7 @@ PLATFORMS
 
 DEPENDENCIES
   activeadmin!
+  autolink
   better_errors
   binding_of_caller
   coffee-rails (~> 4.1.0)
@@ -292,3 +294,6 @@ DEPENDENCIES
   twitter-bootstrap-rails
   uglifier (>= 1.3.0)
   unicorn
+
+BUNDLED WITH
+   1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,6 @@ GEM
     arbre (1.0.3)
       activesupport (>= 3.0.0)
     arel (6.0.3)
-    autolink (3.0.0)
     bcrypt (3.1.10)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -183,6 +182,8 @@ GEM
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
+    rails_autolink (1.1.6)
+      rails (> 3.1)
     rails_serve_static_assets (0.0.4)
     rails_stdout_logging (0.0.4)
     railties (4.2.3)
@@ -269,7 +270,6 @@ PLATFORMS
 
 DEPENDENCIES
   activeadmin!
-  autolink
   better_errors
   binding_of_caller
   coffee-rails (~> 4.1.0)
@@ -285,6 +285,7 @@ DEPENDENCIES
   rack-zippy
   rails (= 4.2.3)
   rails_12factor
+  rails_autolink
   rspec
   rspec-rails
   sass-rails (~> 5.0)

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -27,7 +27,7 @@
         <td><%= location.contact %></td>
         <td><%= location.address %></td>
         <td><%= location.distance.round(2) %> miles away</td>
-        <td><%= location.notes %></td>
+        <td><%= auto_link(location.notes) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -24,7 +24,7 @@
         <td><%= location.name %></td>
         <td><%= location.specialty_names.join(', ') %></td>
         <td><%= location.phone %></td>
-        <td><%= location.contact %></td>
+        <td><%= auto_link(location.contact) %></td>
         <td><%= location.address %></td>
         <td><%= location.distance.round(2) %> miles away</td>
         <td><%= auto_link(location.notes) %></td>


### PR DESCRIPTION
Makes notes on the search result autolinked.  Links not beginning with `http` also works but it seems it must start with `www`.
